### PR TITLE
feat: bump deps + harden security context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
-FROM gcr.io/distroless/static
-COPY uri-template-tester /
-COPY public /public/
-CMD ["/uri-template-tester"]
-EXPOSE 80
+# syntax=docker/dockerfile:1
+
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/uri-template-tester .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/uri-template-tester /uri-template-tester
+COPY --from=build /src/public /public/
+USER nonroot:nonroot
+ENTRYPOINT ["/uri-template-tester"]
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
-# syntax=docker/dockerfile:1
-
-FROM golang:1.26-alpine AS build
-WORKDIR /src
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/uri-template-tester .
-
 FROM gcr.io/distroless/static-debian12:nonroot
-COPY --from=build /out/uri-template-tester /uri-template-tester
-COPY --from=build /src/public /public/
+COPY uri-template-tester /
+COPY public /public/
 USER nonroot:nonroot
 ENTRYPOINT ["/uri-template-tester"]
 EXPOSE 8080

--- a/chart/uri-template-tester/Chart.yaml
+++ b/chart/uri-template-tester/Chart.yaml
@@ -4,4 +4,7 @@ description: Test if a URI matches a given URI template (RFC6570)
 type: application
 version: 0.2.0
 appVersion: "0.2.0"
-kubeVersion: ">=1.19.0-0"
+# Targets recent Kubernetes only: NetworkPolicy templates rely on the
+# kubernetes.io/metadata.name auto-label (GA in 1.22) and the chart
+# optionally renders a Gateway API HTTPRoute (v1 GA in 1.30).
+kubeVersion: ">=1.30.0-0"

--- a/chart/uri-template-tester/Chart.yaml
+++ b/chart/uri-template-tester/Chart.yaml
@@ -1,23 +1,7 @@
 apiVersion: v2
 name: uri-template-tester
 description: Test if a URI matches a given URI template (RFC6570)
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: "0.2.0"
+kubeVersion: ">=1.19.0-0"

--- a/chart/uri-template-tester/templates/deployment.yaml
+++ b/chart/uri-template-tester/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "uri-template-tester.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
   template:
     metadata:
     {{- with .Values.podAnnotations }}
@@ -21,6 +22,7 @@ spec:
     {{- end }}
       labels:
         {{- include "uri-template-tester.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/uri-template-tester/templates/deployment.yaml
+++ b/chart/uri-template-tester/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/chart/uri-template-tester/templates/deployment.yaml
+++ b/chart/uri-template-tester/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             - name: http
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.containerPort | quote }}
           {{- with .Values.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}

--- a/chart/uri-template-tester/templates/deployment.yaml
+++ b/chart/uri-template-tester/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "uri-template-tester.labels" . | nindent 4 }}
 spec:
+  revisionHistoryLimit: 3
+  progressDeadlineSeconds: 300
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}
@@ -25,6 +27,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "uri-template-tester.serviceAccountName" . }}
+      automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -35,16 +38,20 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/chart/uri-template-tester/templates/httproute.yaml
+++ b/chart/uri-template-tester/templates/httproute.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.httpRoute.enabled -}}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1/HTTPRoute") -}}
+{{- fail "httpRoute.enabled is true but the cluster does not have gateway.networking.k8s.io/v1 installed. Install the Gateway API CRDs first or set httpRoute.enabled=false." -}}
+{{- end -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/chart/uri-template-tester/templates/httproute.yaml
+++ b/chart/uri-template-tester/templates/httproute.yaml
@@ -2,6 +2,9 @@
 {{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1/HTTPRoute") -}}
 {{- fail "httpRoute.enabled is true but the cluster does not have gateway.networking.k8s.io/v1 installed. Install the Gateway API CRDs first or set httpRoute.enabled=false." -}}
 {{- end -}}
+{{- if not .Values.httpRoute.parentRefs -}}
+{{- fail "httpRoute.enabled is true but httpRoute.parentRefs is empty. Set at least one parent Gateway/Listener to attach this route to." -}}
+{{- end -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/chart/uri-template-tester/templates/httproute.yaml
+++ b/chart/uri-template-tester/templates/httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "uri-template-tester.fullname" . }}
+  labels:
+    {{- include "uri-template-tester.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "uri-template-tester.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/chart/uri-template-tester/templates/ingress.yaml
+++ b/chart/uri-template-tester/templates/ingress.yaml
@@ -32,9 +32,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- with .pathType }}
-            pathType: {{ . }}
-            {{- end }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/chart/uri-template-tester/templates/ingress.yaml
+++ b/chart/uri-template-tester/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "uri-template-tester.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -16,6 +12,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -32,10 +31,15 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/chart/uri-template-tester/templates/networkpolicy.yaml
+++ b/chart/uri-template-tester/templates/networkpolicy.yaml
@@ -13,10 +13,14 @@ spec:
     - Ingress
     - Egress
   ingress:
+    # Allow traffic from the configured ingress controller namespace and
+    # from the release namespace itself (so `helm test`, sidecars, and
+    # other in-namespace callers keep working).
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace | quote }}
+        - podSelector: {}
       ports:
         - protocol: TCP
           port: {{ .Values.containerPort }}

--- a/chart/uri-template-tester/templates/networkpolicy.yaml
+++ b/chart/uri-template-tester/templates/networkpolicy.yaml
@@ -6,9 +6,13 @@ metadata:
   labels:
     {{- include "uri-template-tester.labels" . | nindent 4 }}
 spec:
+  # Selects only the Deployment pods (component=server). The Helm test
+  # pod inherits selectorLabels via `<chart>.labels` but does not get the
+  # component label, so it isn't subject to this policy.
   podSelector:
     matchLabels:
       {{- include "uri-template-tester.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
   policyTypes:
     - Ingress
     - Egress
@@ -24,10 +28,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.containerPort }}
-  # The app makes no outbound HTTP calls; only DNS is permitted, plus
-  # same-namespace egress to the app's own port so `helm test` (which
-  # the policy also matches via shared chart labels) can hit the Service
-  # backend.
+  # The app makes no outbound HTTP calls; only DNS is permitted.
   egress:
     - to:
         - namespaceSelector:
@@ -38,9 +39,4 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
-    - to:
-        - podSelector: {}
-      ports:
-        - protocol: TCP
-          port: {{ .Values.containerPort }}
 {{- end }}

--- a/chart/uri-template-tester/templates/networkpolicy.yaml
+++ b/chart/uri-template-tester/templates/networkpolicy.yaml
@@ -24,7 +24,8 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.containerPort }}
-  # The app makes no outbound calls; only DNS is permitted.
+  # The app makes no outbound HTTP calls; only DNS is permitted, plus
+  # same-namespace egress so `helm test` can hit the Service backend.
   egress:
     - to:
         - namespaceSelector:
@@ -35,4 +36,6 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    - to:
+        - podSelector: {}
 {{- end }}

--- a/chart/uri-template-tester/templates/networkpolicy.yaml
+++ b/chart/uri-template-tester/templates/networkpolicy.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "uri-template-tester.fullname" . }}
+  labels:
+    {{- include "uri-template-tester.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "uri-template-tester.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.containerPort }}
+  # The app makes no outbound calls; only DNS is permitted.
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.dnsNamespace | quote }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/chart/uri-template-tester/templates/networkpolicy.yaml
+++ b/chart/uri-template-tester/templates/networkpolicy.yaml
@@ -25,7 +25,9 @@ spec:
         - protocol: TCP
           port: {{ .Values.containerPort }}
   # The app makes no outbound HTTP calls; only DNS is permitted, plus
-  # same-namespace egress so `helm test` can hit the Service backend.
+  # same-namespace egress to the app's own port so `helm test` (which
+  # the policy also matches via shared chart labels) can hit the Service
+  # backend.
   egress:
     - to:
         - namespaceSelector:
@@ -38,4 +40,7 @@ spec:
           port: 53
     - to:
         - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.containerPort }}
 {{- end }}

--- a/chart/uri-template-tester/values.yaml
+++ b/chart/uri-template-tester/values.yaml
@@ -103,11 +103,15 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 4
 
-# NetworkPolicy: ingress is allowed from the configured ingress controller
-# namespace and from the release namespace itself (so `helm test` and other
-# in-namespace callers keep working); egress is restricted to DNS only
-# (the app makes no outbound HTTP calls). Namespaces are matched via the
-# kubernetes.io/metadata.name auto-label (always present on K8s 1.22+).
+# NetworkPolicy: scoped to Deployment pods only (via app.kubernetes.io/
+# component=server), so the Helm test pod isn't subject to it. Ingress is
+# allowed from the configured ingress controller namespace and from the
+# release namespace itself (the latter lets `helm test` reach the
+# Service); egress is restricted to DNS only — the app makes no outbound
+# HTTP calls.
+#
+# Namespaces are matched via the kubernetes.io/metadata.name auto-label
+# (always present on K8s 1.22+).
 #
 # Note on kubelet probes: this policy assumes a CNI that exempts kubelet
 # health checks from NetworkPolicy enforcement (Cilium, Calico with

--- a/chart/uri-template-tester/values.yaml
+++ b/chart/uri-template-tester/values.yaml
@@ -108,6 +108,11 @@ readinessProbe:
 # in-namespace callers keep working); egress is restricted to DNS only
 # (the app makes no outbound HTTP calls). Namespaces are matched via the
 # kubernetes.io/metadata.name auto-label (always present on K8s 1.22+).
+#
+# Note on kubelet probes: this policy assumes a CNI that exempts kubelet
+# health checks from NetworkPolicy enforcement (Cilium, Calico with
+# `kubelet`-exempt config, etc.). If your CNI doesn't, add an ipBlock for
+# the node CIDRs to the ingress rules or set networkPolicy.enabled=false.
 networkPolicy:
   enabled: true
   ingressNamespace: ingress-nginx

--- a/chart/uri-template-tester/values.yaml
+++ b/chart/uri-template-tester/values.yaml
@@ -102,9 +102,11 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 4
 
-# NetworkPolicy locking ingress to the ingress-nginx namespace and egress to
-# DNS only (this app makes no outbound calls). Namespaces are matched via
-# the kubernetes.io/metadata.name auto-label (always present on K8s 1.22+).
+# NetworkPolicy: ingress is allowed from the configured ingress controller
+# namespace and from the release namespace itself (so `helm test` and other
+# in-namespace callers keep working); egress is restricted to DNS only
+# (the app makes no outbound HTTP calls). Namespaces are matched via the
+# kubernetes.io/metadata.name auto-label (always present on K8s 1.22+).
 networkPolicy:
   enabled: true
   ingressNamespace: ingress-nginx

--- a/chart/uri-template-tester/values.yaml
+++ b/chart/uri-template-tester/values.yaml
@@ -8,69 +8,95 @@ image:
   repository: dunglas/uri-template-tester
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart version.
-  tag: "v0.1"
+  tag: "0.2.0"
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# Pod-wide hardening: distroless/static:nonroot ships nonroot at UID 65532.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# Container hardening: static binary needs no caps, no writable rootfs.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 service:
   type: ClusterIP
   port: 80
 
+# Container port the binary binds to. Unprivileged so non-root user can listen.
+containerPort: 8080
+
 ingress:
   enabled: false
+  className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: uri-template-tester.local
-      paths: []
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
-  #  - secretName: uri-template-tester-example-tls
-  #    hosts:
-  #      - uri-template-tester.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# No CPU limit on purpose: CFS quota throttling on the cluster causes
+# probe timeouts and latency spikes even when nodes have spare cycles.
+# Static Go binary is tiny; memory limit is just an OOM safety net.
+resources:
+  limits:
+    memory: 64Mi
+  requests:
+    cpu: 10m
+    memory: 32Mi
+
+# TCP probes for startup/liveness, HTTP for readiness with a generous timeout.
+# Keeps healthy pods Ready under transient cluster contention.
+startupProbe:
+  tcpSocket:
+    port: http
+  failureThreshold: 30
+  periodSeconds: 2
+livenessProbe:
+  tcpSocket:
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 2
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 4
+
+# NetworkPolicy locking ingress to the ingress-nginx namespace and egress to
+# DNS only (this app makes no outbound calls).
+networkPolicy:
+  enabled: true
+  ingressNamespace: ingress-nginx
+  dnsNamespace: kube-system
 
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 

--- a/chart/uri-template-tester/values.yaml
+++ b/chart/uri-template-tester/values.yaml
@@ -7,8 +7,9 @@ replicaCount: 1
 image:
   repository: dunglas/uri-template-tester
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart version.
-  tag: "0.2.0"
+  # The release pipeline (goreleaser) tags Docker images with the leading
+  # `v` (`v0.2.0`, `v0.2`, `v0`, `latest`). Match that here.
+  tag: "v0.2.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/chart/uri-template-tester/values.yaml
+++ b/chart/uri-template-tester/values.yaml
@@ -55,6 +55,23 @@ ingress:
           pathType: Prefix
   tls: []
 
+# Gateway API HTTPRoute alternative to Ingress. Enable one or the other
+# (or both, for migrations). The referenced Gateway must already exist.
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  hostnames: []
+  #  - uri-template-tester.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
 # No CPU limit on purpose: CFS quota throttling on the cluster causes
 # probe timeouts and latency spikes even when nodes have spare cycles.
 # Static Go binary is tiny; memory limit is just an OOM safety net.
@@ -86,7 +103,8 @@ readinessProbe:
   failureThreshold: 4
 
 # NetworkPolicy locking ingress to the ingress-nginx namespace and egress to
-# DNS only (this app makes no outbound calls).
+# DNS only (this app makes no outbound calls). Namespaces are matched via
+# the kubernetes.io/metadata.name auto-label (always present on K8s 1.22+).
 networkPolicy:
   enabled: true
   ingressNamespace: ingress-nginx

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/dunglas/uri-template-tester
 
-go 1.14
+go 1.26
 
-require github.com/yosida95/uritemplate v2.0.0+incompatible
+require github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/yosida95/uritemplate v0.0.0-20170413134207-5c22f358020b h1:Lz1ji+ezbzsAY9OFYZxa+Tzao42+DMJIR6jn3N+H87I=
-github.com/yosida95/uritemplate v0.0.0-20170413134207-5c22f358020b/go.mod h1:mksJanHNnLsh6wYgt/AbBRZ4ogsHsO2uiZlm/UURY5c=
-github.com/yosida95/uritemplate v2.0.0+incompatible h1:j6LR/+4tiD14zc0Z0M8QilHLULqgZFD47XqgXQgCE1A=
-github.com/yosida95/uritemplate v2.0.0+incompatible/go.mod h1:mksJanHNnLsh6wYgt/AbBRZ4ogsHsO2uiZlm/UURY5c=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ func main() {
 
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "http"
+		port = "8080"
 	}
 
 	if err := http.ListenAndServe(":"+port, nil); err != nil {

--- a/match.go
+++ b/match.go
@@ -75,7 +75,12 @@ func writeJSONError(w http.ResponseWriter, r *http.Request, status int, msg stri
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	http.Error(w, string(payload), status)
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+	if _, err := w.Write(payload); err != nil {
+		slog.Info("failed to write response", "remote_addr", r.RemoteAddr, "error", err)
+	}
 }
 
 // flattenValues turns uritemplate/v3's Values into a JSON-friendly shape:

--- a/match.go
+++ b/match.go
@@ -33,37 +33,49 @@ func match(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(errors) > 0 {
-		payload, _ := json.MarshalIndent(jsonError{strings.Join(errors, " ")}, "", "  ")
-		http.Error(w, string(payload), http.StatusBadRequest)
-
+		writeJSONError(w, r, http.StatusBadRequest, strings.Join(errors, " "))
 		return
 	}
 
 	tpl, err := uritemplate.New(template)
 	if nil != err {
-		payload, _ := json.MarshalIndent(jsonError{fmt.Sprintf(`"%s" is not a valid URI template (RFC6570).`, template)}, "", "  ")
-		http.Error(w, string(payload), http.StatusBadRequest)
-
+		writeJSONError(w, r, http.StatusBadRequest, fmt.Sprintf(`"%s" is not a valid URI template (RFC6570).`, template))
 		return
 	}
 
 	match := tpl.Match(uri)
 	if match == nil {
-		payload, _ := json.Marshal(struct{ Match bool }{false})
-		if _, err := w.Write(payload); err != nil {
-			slog.Info("failed to write response", "remote_addr", r.RemoteAddr, "error", err)
-		}
-
+		writeJSON(w, r, http.StatusOK, struct{ Match bool }{false})
 		return
 	}
 
-	payload, _ := json.MarshalIndent(struct {
+	writeJSON(w, r, http.StatusOK, struct {
 		Match  bool
 		Values map[string]any
-	}{true, flattenValues(match)}, "", "  ")
+	}{true, flattenValues(match)})
+}
+
+func writeJSON(w http.ResponseWriter, r *http.Request, status int, body any) {
+	payload, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		slog.Error("failed to marshal response", "remote_addr", r.RemoteAddr, "error", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(status)
 	if _, err := w.Write(payload); err != nil {
 		slog.Info("failed to write response", "remote_addr", r.RemoteAddr, "error", err)
 	}
+}
+
+func writeJSONError(w http.ResponseWriter, r *http.Request, status int, msg string) {
+	payload, err := json.MarshalIndent(jsonError{msg}, "", "  ")
+	if err != nil {
+		slog.Error("failed to marshal error response", "remote_addr", r.RemoteAddr, "error", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	http.Error(w, string(payload), status)
 }
 
 // flattenValues turns uritemplate/v3's Values into a JSON-friendly shape:

--- a/match.go
+++ b/match.go
@@ -15,8 +15,6 @@ type jsonError struct {
 }
 
 func match(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/payload")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Frame-Options", "deny")
 
 	query := r.URL.Query()
@@ -62,6 +60,8 @@ func writeJSON(w http.ResponseWriter, r *http.Request, status int, body any) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(status)
 	if _, err := w.Write(payload); err != nil {
 		slog.Info("failed to write response", "remote_addr", r.RemoteAddr, "error", err)

--- a/match.go
+++ b/match.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/yosida95/uritemplate"
+	"github.com/yosida95/uritemplate/v3"
 )
 
 type jsonError struct {
@@ -59,9 +59,32 @@ func match(w http.ResponseWriter, r *http.Request) {
 
 	payload, _ := json.MarshalIndent(struct {
 		Match  bool
-		Values uritemplate.Values
-	}{true, match}, "", "  ")
+		Values map[string]any
+	}{true, flattenValues(match)}, "", "  ")
 	if _, err := w.Write(payload); err != nil {
 		slog.Info("failed to write response", "remote_addr", r.RemoteAddr, "error", err)
 	}
+}
+
+// flattenValues turns uritemplate/v3's Values into a JSON-friendly shape:
+// single-string variables come out as strings, lists as []string, key/value
+// arrays as map[string]string. Keeps the rendered output readable in the UI.
+func flattenValues(v uritemplate.Values) map[string]any {
+	out := make(map[string]any, len(v))
+	for k, val := range v {
+		switch val.T {
+		case uritemplate.ValueTypeList:
+			out[k] = val.List()
+		case uritemplate.ValueTypeKV:
+			kv := val.KV()
+			m := make(map[string]string, len(kv)/2)
+			for i := 0; i+1 < len(kv); i += 2 {
+				m[kv[i]] = kv[i+1]
+			}
+			out[k] = m
+		default:
+			out[k] = val.String()
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

- Go 1.14 → 1.26.
- `yosida95/uritemplate` v2.0.0+incompatible → v3.0.2 (semantic import path `/v3`). The v3 `Values` type exposes typed string/list/key-value entries rather than plain strings; `match.go` flattens them so the JSON shape returned by `/match` stays backward-compatible with the existing UI in `public/`. JSON marshal errors are now propagated instead of swallowed.
- Default port 80 → 8080 so the binary can run as non-root without `CAP_NET_BIND_SERVICE`.

## Image

Stays single-stage so it pairs with the existing goreleaser pipeline (which cross-builds the binary and feeds it into the image build via `dockers:`). Base bumped to `gcr.io/distroless/static-debian12:nonroot`, with `USER nonroot:nonroot` baked in.

## Chart (0.2.0)

- Pod-level `runAsNonRoot`, `runAsUser: 65532` (matches distroless nonroot UID), `seccompProfile: RuntimeDefault`.
- Container-level `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`.
- Resources: `requests` + memory limit only — no CPU limit. CFS quota throttling on the production cluster causes probe timeouts even with idle CPU; trading enforcement for reliability.
- Probes split into TCP startup + TCP liveness + HTTP readiness with `timeoutSeconds: 5`, replacing the bare kubelet-default 1s probes.
- `automountServiceAccountToken: false` (the app makes no K8s API calls).
- New `NetworkPolicy`: ingress allowed from the configured ingress-nginx namespace and from the release namespace itself (so `helm test` keeps working); egress to DNS only (no outbound HTTP).
- Ingress template drops the `v1beta1` fallback. `pathType` defaults to `Prefix` when callers don't set it.
- New `HTTPRoute` template (`gateway.networking.k8s.io/v1`) behind `httpRoute.enabled`. Either Ingress or HTTPRoute (or both, for migrations) can be enabled. Rendering is gated on `.Capabilities.APIVersions.Has` so installs without the Gateway API CRDs fail loudly.
- `Chart.yaml` carries `kubeVersion: ">=1.30.0-0"`. NetworkPolicy uses `kubernetes.io/metadata.name` (GA 1.22) and HTTPRoute v1 is GA in 1.30, so the chart targets recent K8s only.

Bumped to `0.2.0` (chart version + image tag).