### PR TITLE
chore: target v2.0.0 image for the next release

### DIFF
--- a/chart/uri-template-tester/Chart.yaml
+++ b/chart/uri-template-tester/Chart.yaml
@@ -3,7 +3,7 @@ name: uri-template-tester
 description: Test if a URI matches a given URI template (RFC6570)
 type: application
 version: 0.2.0
-appVersion: "0.2.0"
+appVersion: "2.0.0"
 # Targets recent Kubernetes only: NetworkPolicy templates rely on the
 # kubernetes.io/metadata.name auto-label (GA in 1.22) and the chart
 # optionally renders a Gateway API HTTPRoute (v1 GA in 1.30).

--- a/chart/uri-template-tester/values.yaml
+++ b/chart/uri-template-tester/values.yaml
@@ -8,8 +8,8 @@ image:
   repository: dunglas/uri-template-tester
   pullPolicy: IfNotPresent
   # The release pipeline (goreleaser) tags Docker images with the leading
-  # `v` (`v0.2.0`, `v0.2`, `v0`, `latest`). Match that here.
-  tag: "v0.2.0"
+  # `v` (`v2.0.0`, `v2.0`, `v2`, `latest`). Match that here.
+  tag: "v2.0.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
The previous tag was [v1.0.0](https://github.com/dunglas/uri-template-tester/releases/tag/v1.0.0). [#10](https://github.com/dunglas/uri-template-tester/pull/10) breaks both image consumers (default listen port 80 → 8080 so the binary can run as non-root) and chart consumers (`paths` schema, `containerPort` value, NetworkPolicy defaults), so the next release is a major bump.

Chart's `image.tag` and `appVersion` move to `v2.0.0`. The chart's own `version` stays at `0.2.0` since chart-level packaging is independent.