### PR TITLE
fix(docker): set WORKDIR / so public/ is resolvable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM gcr.io/distroless/static-debian12:nonroot
+WORKDIR /
 COPY uri-template-tester /
 COPY public /public/
 USER nonroot:nonroot


### PR DESCRIPTION
`gcr.io/distroless/static-debian12:nonroot` sets `WORKDIR /home/nonroot` by default. The binary's `http.FileServer(http.Dir("public"))` resolves `"public"` relative to the process cwd, so without an explicit `WORKDIR /` the static assets at `/public/` aren't reachable and `/`, `/app.js`, etc. return 404 (`/index.html` returns a 301 redirect to `./` which is the giveaway — Go stdlib FileServer normalises a request that ends in `index.html`).

Pinning `WORKDIR /` matches where `COPY` placed both the binary (`/uri-template-tester`) and the `public/` directory (`/public/`).

Reproduces locally with `docker run -p 8080:8080 dunglas/uri-template-tester:v2.0.0` then `curl http://localhost:8080/`.