### PR TITLE
chore(chart): tighten secure-by-default settings

### DIFF
--- a/chart/uri-template-tester/templates/deployment.yaml
+++ b/chart/uri-template-tester/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "uri-template-tester.serviceAccountName" . }}
       automountServiceAccountToken: false
+      # The static binary serves a single HTTP endpoint and reads no
+      # service-discovery env vars, so suppress the K8s default that
+      # injects every neighbour Service's host/port into the pod.
+      enableServiceLinks: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/chart/uri-template-tester/templates/serviceaccount.yaml
+++ b/chart/uri-template-tester/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: false
 {{- end }}

--- a/chart/uri-template-tester/templates/tests/test-connection.yaml
+++ b/chart/uri-template-tester/templates/tests/test-connection.yaml
@@ -7,9 +7,26 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
+  # The test pod calls a single HTTP endpoint, so no Kubernetes API
+  # access, no service-link env, and no privileged execution is needed.
+  # Stays compatible with the restricted PodSecurity Standard.
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: wget
-      image: busybox
+      image: busybox:1.37
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
       command: ['wget']
-      args: ['{{ include "uri-template-tester.fullname" . }}:{{ .Values.service.port }}']
+      args: ['-q', '--spider', 'http://{{ include "uri-template-tester.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never


### PR DESCRIPTION
Bring the chart in line with the same secure-by-default pattern the
upstream mercure chart now ships:

- `enableServiceLinks: false` on the pod spec. The static binary
  serves a single HTTP endpoint and reads no service-discovery env
  vars, so suppress the K8s default that injects every neighbour
  Service's host/port into the pod.
- `automountServiceAccountToken: false` on the ServiceAccount as a
  belt-and-suspenders match for the existing pod-level setting.
- Harden the helm test pod (pinned `busybox:1.37`, no SA token, no
  service links, RuntimeDefault seccomp, drop ALL caps, RO rootfs,
  non-root, `wget -q --spider` so the response body is not written
  to disk under RO rootfs).